### PR TITLE
fix: remove cmake version to use default cmake from android studio env

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,6 @@ android {
     externalNativeBuild {
         cmake {
             path '../lib/CMakeLists.txt'
-            version "3.22.1"
         }
     }
 }


### PR DESCRIPTION
I deleted the line with the specific cmake version assignment because after deleting that line the default cmake from the android stuio environment will be used.

[Documentation](https://developer.android.com/studio/projects/install-ndk#vanilla_cmake)
